### PR TITLE
fix(JAQPOT-325): accept jaqpotInternalId

### DIFF
--- a/R/predict_caret.R
+++ b/R/predict_caret.R
@@ -17,7 +17,9 @@ predict.caret <- function(modelDto, datasetDto, doa) {
 
   # Convert data types
   for (j in 1:dim(df)[2]) {
-    if (feat.types[colnames(df)[j]] == "FLOAT") {
+    if(colnames(df)[j] == "jaqpotInternalId"){
+      next
+    }else if (feat.types[colnames(df)[j]] == "FLOAT") {
       df[, j] <- as.numeric(df[, j])
     }else if (feat.types[colnames(df)[j]] == "INTEGER") {
       df[, j] <- as.integer(df[, j])

--- a/R/predict_pbpk.R
+++ b/R/predict_pbpk.R
@@ -17,7 +17,9 @@ predict.pbpk <- function(modelDto, datasetDto, doaDto){
 
   # Convert data types
   for (j in 1:dim(df)[2]){
-    if (feat.types[colnames(df)[j]] == "FLOAT"){
+    if(colnames(df)[j] == "jaqpotInternalId"){
+      next
+    }else if (feat.types[colnames(df)[j]] == "FLOAT"){
       df[,j] <- as.numeric( df[,j] )
     }else if (feat.types[colnames(df)[j]] == "INTEGER"){
       df[,j] <- as.integer( df[,j] )


### PR DESCRIPTION
when passing jaqpotInternalId in the input on jaqpotr-inference it was failing cause it couldn't handle that input key. Adding code to skip that issue. 

jaqpotInternalId is an internal key we add to the input and the result so we can match an input row with the results row.

e.g. if a model is returning 3 rows of results they have to have the same jaqpotInternalId as the input so we know that these results came from the input row that has the same jaqpotInternalId 